### PR TITLE
fixed deleted way for river Schlei

### DIFF
--- a/src/com/skaringa/riversystem/WellknownRivers.java
+++ b/src/com/skaringa/riversystem/WellknownRivers.java
@@ -58,7 +58,7 @@ public class WellknownRivers {
     id2Basin.put(5005413L, TRAVE);
     id2Basin.put(29249972L, TRAVE); // Schwentine
     id2Basin.put(104383228L, TRAVE); // Stepenitz
-    id2Basin.put(219919816L, SCHLEI);
+    id2Basin.put(23859221L, SCHLEI); // Füsinger Au
     id2Basin.put(98726563L, EIDER); // Arlau
     id2Basin.put(52997220L, EIDER); // Miele
     id2Basin.put(5011995L, EIDER);


### PR DESCRIPTION
The Fjord Schlei isn't a river anymore, so the way referenced in WellknownRivers was deleted some time ago.

May I suggest to take its largest tributary Füsinger Au as a replacement?