### PR TITLE
set of divides for taking coastlines into account

### DIFF
--- a/src/com/skaringa/riversystem/WellknownRivers.java
+++ b/src/com/skaringa/riversystem/WellknownRivers.java
@@ -52,7 +52,7 @@ public class WellknownRivers {
     id2Basin.put(118848751L, ELBE); // Eger
     id2Basin.put(89253786L, ODER);
     id2Basin.put(4488193L, WARNOW);
-    id2Basin.put(161734566L, WARNOW); // Recknitz
+//    id2Basin.put(161734566L, WARNOW); // Recknitz
     id2Basin.put(4532243L, PEENE);
     id2Basin.put(1211198775L, TRAVE);
 //    id2Basin.put(29249972L, TRAVE); // Schwentine
@@ -92,12 +92,18 @@ public class WellknownRivers {
     divides.add(29915851L); // Main-Donau-Kanal
     divides.add(35963164L); //dto.
     divides.add(284797683L); // dto.
-    divides.add(102832333L); // Der Strom
     divides.add(88817869L); // Hausseebruchgraben
+    divides.add(733422822L); // Küste Oder rechts
+    divides.add(30421371L); // Küste Peene rechts
+    divides.add(102832365L); // Der Strom
+    divides.add(95799872L); // Küste Peene rechts
     divides.add(28406303L); // Küste Trave rechts
     divides.add(25976489L); // Küste Schlei links
     divides.add(347556100L); // Küste Eider rechts
     divides.add(4100668L); // Küste Elbe rechts
+    divides.add(4096524L); // Küste Weser rechts
+    divides.add(159679203L); // Küste Ems rechts
+    divides.add(921082861L); // Küste Rhein rechts
     divides.add(28070936L); // Nord-Ostsee-Kanal
     divides.add(131279449L); // alte Schleuse Kiel-Holtenau Nordkammer
     divides.add(73034121L); // alte Schleuse Kiel-Holtenau Nordkammer

--- a/src/com/skaringa/riversystem/WellknownRivers.java
+++ b/src/com/skaringa/riversystem/WellknownRivers.java
@@ -55,11 +55,11 @@ public class WellknownRivers {
     id2Basin.put(161734566L, WARNOW); // Recknitz
     id2Basin.put(4532243L, PEENE);
     id2Basin.put(1211198775L, TRAVE);
-    id2Basin.put(29249972L, TRAVE); // Schwentine
-    id2Basin.put(104383228L, TRAVE); // Stepenitz
+//    id2Basin.put(29249972L, TRAVE); // Schwentine
+//    id2Basin.put(104383228L, TRAVE); // Stepenitz
     id2Basin.put(23859221L, SCHLEI); // Füsinger Au
-    id2Basin.put(98726563L, EIDER); // Arlau
-    id2Basin.put(52997220L, EIDER); // Miele
+//    id2Basin.put(98726563L, EIDER); // Arlau
+//    id2Basin.put(52997220L, EIDER); // Miele
     id2Basin.put(5011995L, EIDER);
     id2Basin.put(29432442L, ELBE); // Obere Eider
                                    // (http://de.wikipedia.org/wiki/Eider)
@@ -94,6 +94,10 @@ public class WellknownRivers {
     divides.add(284797683L); // dto.
     divides.add(102832333L); // Der Strom
     divides.add(88817869L); // Hausseebruchgraben
+    divides.add(28406303L); // Küste Trave rechts
+    divides.add(25976489L); // Küste Schlei links
+    divides.add(347556100L); // Küste Eider rechts
+    divides.add(4100668L); // Küste Elbe rechts
     divides.add(28070936L); // Nord-Ostsee-Kanal
     divides.add(131279449L); // alte Schleuse Kiel-Holtenau Nordkammer
     divides.add(73034121L); // alte Schleuse Kiel-Holtenau Nordkammer

--- a/tags-filter.txt
+++ b/tags-filter.txt
@@ -1,3 +1,4 @@
 w/waterway=stream,river,ditch,canal,drain,weir,dam,waterfall,fish_pass
+w/natural=coastline
 a/natural=water
 a/landuse=reservoir,basin


### PR DESCRIPTION
A demonstration to cover a lot more waterways by taking coastlines into account.

I have done that almost 10 years ago to validate small streams at the coast of Schleswig-Holstein. Somehow I lost Interest and forgot to tell you about.
![rivermap_sh_coastline](https://github.com/skaringa/rivers/assets/5358268/e4a793f6-ea76-4421-a374-6a2c21a08ce9)

Sorry about the rendering, I am not so good at tilemill.